### PR TITLE
CAS-1306. Change minimal required version of numpy

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -191,7 +191,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "e3842d3c7ace9e26205735449c617ac795dd2cc6caec8f92499877a011f1757f"
+content-hash = "4b8c154ba1c39e7089dd18ddb7a39cd105166f20e7bdff12202b0470c74e4c4d"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyiqfeed"
-version = "0.10"
+version = "0.10.1"
 description = "Handles connections to IQFeed, the market data feed by DTN"
 authors = [
     "Ashwin Kapur <ashwin.kapur@gmail.com>",
@@ -10,7 +10,7 @@ license = "GPL-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-numpy = "^1.20.1"
+numpy = "^1.18"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.7.0"


### PR DESCRIPTION
This should help to avoid dependency resolution issues when old versions of `mlfinlab` are used.